### PR TITLE
Improve monorepo support

### DIFF
--- a/src/frameworks/laravel.ts
+++ b/src/frameworks/laravel.ts
@@ -6,7 +6,7 @@ import { LanguageId } from '~/utils'
 class LaravelFramework extends Framework {
   id = 'laravel'
   display = 'Laravel'
-  monopoly = true
+  monopoly = false
 
   detection = {
     composerJSON: [

--- a/src/frameworks/react-i18next.ts
+++ b/src/frameworks/react-i18next.ts
@@ -27,6 +27,12 @@ class ReactI18nextFramework extends Framework {
     'ejs',
   ]
 
+  enabledParsers?: string[] | undefined = [
+    'json',
+    'yaml',
+    'json5',
+  ]
+
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
     '\\Wt\\(\\s*[\'"`]({key})[\'"`]',

--- a/src/packagesParsers/base.ts
+++ b/src/packagesParsers/base.ts
@@ -1,12 +1,32 @@
 import fs from 'fs'
+import path from 'path'
 import { File, Log } from '~/utils'
 
 export abstract class PackageParser {
   static filename: string
 
   static load(root: string) {
-    const filepath = `${root}/${this.filename}`
-    if (!fs.existsSync(filepath)) {
+    const packageFilepaths = new Set<string>()
+    const rootPackageFilepath = path.join(root, this.filename)
+    if (fs.existsSync(rootPackageFilepath))
+      packageFilepaths.add(rootPackageFilepath)
+
+    function traverseDirectory(subdir: string, filename: string, ignoreDirectories: string[] = []) {
+      const packageFilepath = path.join(subdir, filename)
+      if (fs.existsSync(packageFilepath))
+        packageFilepaths.add(packageFilepath)
+
+      const subdirs = fs
+        .readdirSync(subdir, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory() && !ignoreDirectories.includes(dirent.name))
+        .map(dirent => path.join(subdir, dirent.name))
+      for (const subdir of subdirs)
+        traverseDirectory(subdir, filename, ignoreDirectories)
+    }
+
+    traverseDirectory(root, this.filename, this.ignoreDirectories())
+
+    if (packageFilepaths.size === 0) {
       Log.info(`🕳 Packages file "${this.filename}" not exists`)
       return undefined
     }
@@ -14,12 +34,15 @@ export abstract class PackageParser {
     Log.info(`📦 Packages file "${this.filename}" found`)
 
     try {
-      const raw = this.loadFile(filepath)
-      const data = this.parserRaw(raw)
+      const data: string[] = []
+      for (const filepath of packageFilepaths) {
+        const raw = this.loadFile(filepath)
+        data.push(...this.parserRaw(raw))
+      }
       return data
     }
     catch (err) {
-      Log.info(`⚠ Error on parsing package file "${this.filename}"`)
+      Log.info(`⚠ Error on parsing package file "${this.filename}" within folder tree of "${root}"`)
     }
 
     return undefined
@@ -27,6 +50,10 @@ export abstract class PackageParser {
 
   protected static loadFile(filepath: string) {
     return File.readSync(filepath)
+  }
+
+  protected static ignoreDirectories() {
+    return ['.git']
   }
 
   protected static parserRaw(raw: string) {

--- a/src/packagesParsers/composerJSON.ts
+++ b/src/packagesParsers/composerJSON.ts
@@ -3,6 +3,10 @@ import { PackageParser } from './base'
 export class ComposerJSONParser extends PackageParser {
   static filename = 'composer.json'
 
+  protected static ignoreDirectories(): string[] {
+    return ['vendor', '.git']
+  }
+
   protected static parserRaw(raw: string) {
     const {
       require = {},

--- a/src/packagesParsers/packageJSON.ts
+++ b/src/packagesParsers/packageJSON.ts
@@ -3,6 +3,10 @@ import { PackageParser } from './base'
 export class PackageJSONParser extends PackageParser {
   static filename = 'package.json'
 
+  protected static ignoreDirectories(): string[] {
+    return ['node_modules', '.git']
+  }
+
   protected static parserRaw(raw: string) {
     const {
       dependencies = {},


### PR DESCRIPTION
real author: @mkevinosullivan

I'm creating this draft PR to discuss these proposed changes before we create a PR against the upstream branch (this way we can avoid pinging lokalize until we're happy with changes on our side).

Technically, we can comment directly on a commit, but then any discussion is basically impossible to find if further changes are made on the branch that overwrite the commit.

> Update abstract class PackageParser to look for the given package file in each folder of a given root directory. This allows for a deep scan to find potential frameworks that need to be supported.