### PR TITLE
Fixes usage report for non-missing derived keys

### DIFF
--- a/src/frameworks/i18next-shopify.ts
+++ b/src/frameworks/i18next-shopify.ts
@@ -13,6 +13,27 @@ class ShopifyI18nextFramework extends ReactI18nextFramework {
       '@shopify/i18next-shopify',
     ],
   }
+
+  derivedKeyRules = [
+    '{key}.plural',
+    '{key}.0',
+    '{key}.1',
+    '{key}.2',
+    '{key}.3',
+    '{key}.4',
+    '{key}.5',
+    '{key}.6',
+    '{key}.7',
+    '{key}.8',
+    '{key}.9',
+    // support v4 format as well as v3
+    '{key}.zero',
+    '{key}.one',
+    '{key}.two',
+    '{key}.few',
+    '{key}.many',
+    '{key}.other',
+  ]
 }
 
 export default ShopifyI18nextFramework


### PR DESCRIPTION
Derived keys (e.g., such as plurals) were being miscategorised as missing in the usage report.

This commit checks if keys derived from those found in the missing list (keys that are in use but considered "not defined") are included in the list of idle keys (keys defined but not considered in use), indicating that they are indeed defined and in use.

Fixes https://github.com/lokalise/i18n-ally/issues/953

Background:
Assuming a locale setup of
```json
{
  "count": {
    "one": "{count} message",
    "other": "{count} messages",
  }
}
```

In a `nested` key scenario, where we use just the `"count"` part as the key in, say, `t("count", { count: 1})`, `"count"` is considered "missing" (in use, but not defined") and `"count.one"` and `"count.other"` are considered "idle" (defined but not in use).